### PR TITLE
🔧 Chore: .vite 캐시 디렉토리 Git에서 제거

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "7f14ef4d",
-  "configHash": "743ba1f6",
-  "lockfileHash": "e3b0c442",
-  "browserHash": "bd0b8bfa",
-  "optimized": {},
-  "chunks": {}
-}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
## 📝작업 내용

1.  .vite 캐시 디렉토리 Git에서 제거
